### PR TITLE
[#8] feat: api types 정리

### DIFF
--- a/src/types/AccessTypes.ts
+++ b/src/types/AccessTypes.ts
@@ -1,0 +1,54 @@
+// Req : Request
+// Res : Response
+
+//로그인
+// /api/login
+export interface LoginReq {
+  email: string
+  password: string
+}
+
+// interface LoginRes {
+//   statusCode: number
+//   data: LoginResData
+// }
+
+export interface LoginResData {
+  user: User
+  token: string
+}
+
+// LoginRes.data
+export interface User {
+  email: string
+  name: string
+  employNumber: string
+  role: 'ROLE_ADMIN' | 'ROLE_USER'
+}
+
+// 회원가입
+// /api/signup
+export interface SignupReq {
+  email: string // 사용자 아이디 (필수!)
+  name: string // 사용자 이름, 20자 이하 (필수!)
+  password: string // 사용자 비밀번호, 8자 이상 (필수!)
+  employeeNumber: string // 사원번호(uuid) 생성한 uuid 값 그대로!
+}
+
+// interface SignupRes {
+//   statusCode: number // 201 Created
+//   data: Message
+// }
+
+// signupRes.data
+export interface Message {
+  message: string
+}
+// 실패 시 statusCode: 400, message: '이미 존재하는 이메일입니다.'
+
+// 로그아웃
+//POST /api/logout
+// \ -H 'Authorization: "asjldhaslkjdhaslkjdhalskjdhalskj"'
+// req 없음
+
+// res 200 OK

--- a/src/types/AdminTypes.ts
+++ b/src/types/AdminTypes.ts
@@ -1,0 +1,102 @@
+// 사용자 목록 조회
+// GET /api/admin/user
+// \ -H 'Authorization: "asjldhaslkjdhaslkjdhalskjdhalskj"'
+
+// Req : 없음
+// Res 200 OK
+// interface userListRes {
+//   statusCode: number
+//   data: userListData
+// }
+
+export type userListData = userInfo[]
+
+export interface userInfo {
+  id: number
+  email: string // 사용자 아이디
+  name: string // 사용자 이름
+  employeeNumber: string
+  restAnnual: number
+  workDay: number
+}
+
+// 사용자 계정 삭제
+// DELETE /api/admin/user/{id}
+// \ -H 'Authorization: "asjldhaslkjdhaslkjdhalskjdhalskj"'
+
+// Req : 없음
+// Res 200 OK
+
+// 당직 등록
+// POST /api/admin/work
+// \ -H 'Authorization: "asjldhaslkjdhaslkjdhalskjdhalskj"'
+
+export interface workRegistReq {
+  id: number
+  date: string // YYYY-MM-DD
+}
+
+// Res 201 Created
+// interface workRegistRes {
+//   statusCode: number
+//   data: workRegistData
+// }
+
+export interface workRegistData {
+  message: string // "당직 등록에 성공했습니다"
+}
+
+// 당직 삭제
+// DELETE /api/admin/work/{workId}
+// \ -H 'Authorization: "asjldhaslkjdhaslkjdhalskjdhalskj"'
+// 당직 일정의 workId를 함께 요청
+
+// Req: 없음
+// Res 200 OK
+
+// 관리자 연차 조회
+// GET /api/admin/annual
+// \ -H 'Authorization: "asjldhaslkjdhaslkjdhalskjdhalskj"'
+
+// Req : 없음
+// Res 200 OK
+// interface annualAdminRes {
+//   statusCode: number
+//   data: annualAdminData
+// }
+
+export type annualAdminData = annualAdminInfo[]
+
+export interface annualAdminInfo {
+  annualId: number
+  name: string
+  employeeNumber: string
+  date: string
+  status: 'UNAPPROVED' | 'CANCELED'
+}
+
+// 관리자 연차 승인
+// POST /api/admin/annual/{annualId}
+// \ -H 'Authorization: "asjldhaslkjdhaslkjdhalskjdhalskj"'
+// status가 CANCELED인 경우 해당 연차는 삭제
+// status가 `UNAPPROVED`인 경우 해당 연차의 상태를 `APPROVED`로 변경
+
+// Req : 없음
+// Res 200 OK
+// interface annualAdminApproveRes {
+//   statusCode: number
+//   data: annualAdminApproveData
+// }
+
+export interface annualAdminApproveData {
+  message: string // "승인되었습니다"
+}
+
+// 관리자 연차 거부
+// DELETE /api/admin/annual/{annualId}
+// \ -H 'Authorization: "asjldhaslkjdhaslkjdhalskjdhalskj"'
+// - status가 `CANCELED`인 경우 해당 연차의 상태를 다시 `APPROVED`로 변경
+// - status가 `UNAPPROVED`인 경우 해당 연차를 삭제
+
+// Req : 없음
+// Res 200 OK

--- a/src/types/MainTypes.ts
+++ b/src/types/MainTypes.ts
@@ -1,0 +1,63 @@
+// 일정목록 조회 (연차)
+// GET /api/schedule/annual?year={2023}&month={7}
+
+// requestData : 없음
+
+// Res 200 OK
+// interface annualRes {
+//   statusCode: number
+//   data: annualData
+// }
+
+// Status가 Approved, Canceled 상태인 것만 가져옴.
+// Res.data
+export interface annualData {
+  [key: number]: annualInfo[]
+}
+
+export interface annualInfo {
+  annualId: number // 연차 아이디
+  name: string // 연차 사용자 이름
+  employeeNumber: string // 연차 사용자 사원번호
+}
+
+// 일정 목록 조회(당직)
+// GET /api/schedule/work?year={year}&month={month}
+// requestData : 없음
+// Res 200 Ok
+// interface workRes {
+//   statusCode: number
+//   data: workData
+//   employeeNumber: string
+// }
+
+// Status가 Approved, Canceled 상태인 것만 가져옴.
+// Res.data
+export interface workData {
+  [key: number]: workInfo[]
+}
+
+export interface workInfo {
+  workId: number // 당직 아이디
+  name: string // 당직 근무자 이름
+  employeeNumber: string // 당직 근무자 사원번호
+}
+
+// 연차 등록 신청
+// POST /api/schedule/annual
+// \ -H 'Authorization: "asjldhaslkjdhaslkjdhalskjdhalskj"'
+
+// Req
+export interface annualApplyReq {
+  date: string // 연차 신청 날짜 (YYYY-MM-DD)
+}
+
+// Res 201 Created
+// interface annualApplyRes {
+//   statusCode: number
+//   data: annualApplyData
+// }
+
+export interface annualApplyData {
+  message: string // "연차 등록에 성공했습니다"
+}

--- a/src/types/MypageTypes.ts
+++ b/src/types/MypageTypes.ts
@@ -1,0 +1,56 @@
+// 개인 연차 조회
+// GET /api/user/annual?year={year}
+// \ -H 'Authorization: "asjldhaslkjdhaslkjdhalskjdhalskj"'
+
+// Req : 없음
+// Res 200 OK
+// interface annualUserRes {
+//   statusCode: number
+//   data: annualUserData
+// }
+
+export type annualUserData = annuals[]
+
+export interface annuals {
+  annualId: number
+  date: string
+  status: 'APPROVED' | 'CANCELED' | 'UNAPPROVED'
+}
+
+// 개인 연차 취소 / 취소 신청
+// POST /api/user/annual/{annualId}
+// \ -H 'Authorization: "asjldhaslkjdhaslkjdhalskjdhalskj"'
+// - 신청한 연차 (UNAPPROVED)
+//     - 바로 삭제됨
+// - 승인된 연차 (APPROVED)
+//     - 상태가 CANCELED로 바뀌고, 관리자 취소 목록에 보이게됨.
+//     - 관리자가 취소 승인하면 그때 삭제됨
+
+// req : 없음
+// Res 200 OK
+// interface annualCancelRes {
+//   statusCode: number
+//   data: annualCancelData
+// }
+export interface annualCancelData {
+  message: string // "연차 취소가 완료되었습니다" | "연차 취소 신청이 완료되었습니다"
+}
+
+// 개인 당직 조회
+// GET /api/user/work?year={year}&month={month}
+// \ -H 'Authorization: "asjldhaslkjdhaslkjdhalskjdhalskj"'
+
+// Req : 없음
+
+// Res 200 OK
+// interface workUserRes {
+//   statusCode: number
+//   data: workUserData
+// }
+
+export type workUserData = works[]
+
+export interface works {
+  workId: number
+  date: string // YYYY-MM-DD
+}


### PR DESCRIPTION
api 요청 / 응답 타입을 typescript로 정리했습니다.
추후 더미데이터나 api를 다루실 때 해당 타입을 꺼내 쓰시면 될 것 같습니다.

노션 기준으로
```
Access : 로그인/회원가입/로그아웃
Admin : 관리자 페이지
MyPage: 마이페이지
Main: 메인
```
에 해당하는 API타입을 정리했습니다.