### PR TITLE
Feat/headerfooter #11

### DIFF
--- a/public/DummyUser.json
+++ b/public/DummyUser.json
@@ -1,0 +1,12 @@
+{
+  "statusCode": 200,
+  "data": {
+    "user": {
+      "email": "test@naver.com",
+      "name": "김테스트",
+      "employeeNumber": "123123",
+      "role": "ROLE_ADMIN | ROLE_USER"
+    },
+    "token": "eyJhbGciOiJIUz"
+  }
+}

--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -2,3 +2,5 @@ $bg-grey: #a3a1a1;
 $bg-lightgrey: #e3dede;
 $bg-sub-grey: #8b8687;
 $bg-black: #333030;
+$bg-blue: #3788d8;
+$bg-lightblue: #e6f0ff;

--- a/src/components/common/MainFooter.module.scss
+++ b/src/components/common/MainFooter.module.scss
@@ -1,5 +1,27 @@
+@import '@/_variables.scss';
+
 .container {
   width: 100%;
   height: 80px;
-  border: 1px solid red; // 추후 삭제
+  background-color: $bg-grey;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  flex-direction: column;
+  .des {
+    font-size: 16px;
+    font-weight: 700;
+    margin-right: 20px;
+  }
+  .link {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    text-decoration: none;
+    color: $bg-black;
+    font-size: 16px;
+    font-weight: 700;
+    margin-top: 10px;
+    margin-right: 20px;
+  }
 }

--- a/src/components/common/MainFooter.tsx
+++ b/src/components/common/MainFooter.tsx
@@ -1,7 +1,14 @@
 import style from './MainFooter.module.scss'
-
+import { AiFillGithub } from 'react-icons/ai'
 const MainFooter = () => {
-  return <div className={style.container}>MainFooter</div>
+  return (
+    <div className={style.container}>
+      <div className={style.des}>Fast Campus MiniProject TEAM2</div>
+      <a className={style.link} href="https://github.com/FAST-Mini-Project" target="_blank">
+        GitHub <AiFillGithub size="24" />
+      </a>
+    </div>
+  )
 }
 
 export default MainFooter

--- a/src/components/common/MainHeader.module.scss
+++ b/src/components/common/MainHeader.module.scss
@@ -1,5 +1,51 @@
+@import '@/_variables.scss';
+
 .container {
   width: 100%;
   height: 120px;
-  border: 1px solid red; // 추후 삭제. 영역잡기용
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  position: relative;
+  border-bottom: solid 1px $bg-sub-grey;
+  margin-bottom: 15px;
+  .userInfo {
+    width: 250px;
+    height: 100px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border-radius: 7px;
+    flex-direction: column;
+    border-bottom: solid 2px $bg-blue;
+    border-right: solid 2px $bg-blue;
+    .wrapper {
+      width: 230px;
+      height: 90px;
+      background-color: #fff;
+      border-radius: 5px;
+      display: flex;
+      justify-content: center;
+      flex-direction: column;
+      div {
+        margin: 3px 10px;
+      }
+    }
+  }
+  .welcomeWrapper {
+    width: 400px;
+    display: flex;
+    justify-content: space-between;
+    font-size: 18px;
+    font-weight: 500;
+    position: absolute;
+    right: 0;
+    bottom: 15px;
+    .link {
+      cursor: pointer;
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
 }

--- a/src/components/common/MainHeader.tsx
+++ b/src/components/common/MainHeader.tsx
@@ -1,7 +1,73 @@
 import style from './MainHeader.module.scss'
+import { useEffect, useState } from 'react'
+import axios from 'axios'
+import { User } from '@/types/AccessTypes'
+import { useLocation, useNavigate } from 'react-router-dom'
 
 const MainHeader = () => {
-  return <div className={style.container}>MainHeader</div>
+  const [user, setUser] = useState<User>({
+    email: '',
+    name: '',
+    employeeNumber: '',
+    role: 'ROLE_USER'
+  })
+  const [link, setLink] = useState<string>('')
+  const location = useLocation()
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    if (location.pathname === '/') {
+      setLink('마이페이지')
+    } else {
+      setLink('일정 조회하러 가기')
+    }
+  }, [location.pathname])
+
+  useEffect(() => {
+    fetchUserInfo()
+  }, [])
+
+  const fetchUserInfo = async () => {
+    try {
+      const { data } = await axios.get('/DummyUser.json')
+      console.log(data)
+      const resData: User = data.data.user
+      setUser(resData)
+      console.log(resData.name)
+      console.log(resData.employeeNumber)
+      console.log(resData.email)
+    } catch (error) {
+      console.log('유저 정보를 가져오는데 실패했습니다.')
+    }
+  }
+
+  const handleLink = () => {
+    if (location.pathname === '/') {
+      navigate('/mypage')
+    } else {
+      navigate('/')
+    }
+  }
+
+  return (
+    <div className={style.container}>
+      <div className={style.userInfo}>
+        <div className={style.wrapper}>
+          <div>{`이름: ${user.name}`}</div>
+          <div>{`사번: ${user.employeeNumber}`}</div>
+          <div>{`이메일: ${user.email}`}</div>
+        </div>
+      </div>
+      <div className={style.welcomeWrapper}>
+        <div>
+          {user.name} #{user.employeeNumber?.slice(0, 4)}님 환영합니다.
+        </div>
+        <div className={style.link} onClick={handleLink}>
+          {link}
+        </div>
+      </div>
+    </div>
+  )
 }
 
 export default MainHeader

--- a/src/components/main/CalendarForm.tsx
+++ b/src/components/main/CalendarForm.tsx
@@ -56,9 +56,9 @@ const CalendarForm = () => {
         initialView="dayGridMonth"
         plugins={[dayGridPlugin, interactionPlugin]}
         headerToolbar={{
-          start: '',
+          start: 'today',
           center: 'title',
-          end: 'today prev next'
+          end: 'prev next'
         }}
         editable={true}
         selectable={true}

--- a/src/components/main/CalendarForm.tsx
+++ b/src/components/main/CalendarForm.tsx
@@ -3,8 +3,8 @@ import dayGridPlugin from '@fullcalendar/daygrid'
 import interactionPlugin from '@fullcalendar/interaction'
 // import style from './CalendarForm.module.scss'
 import { useState, useEffect, useRef } from 'react'
-import _ from 'lodash'
 import axios from 'axios'
+import { annualData } from '@/types/MainTypes'
 
 interface EventObject {
   title: string
@@ -31,10 +31,10 @@ const CalendarForm = () => {
   const fetchDummy = async () => {
     try {
       const response = await axios.get(`/DummyAllAnnual${year}${month}.json`)
-      const resData = response.data
+      const resData: annualData = response.data.data
       // 이벤트 생성
       const events = []
-      for (const [day, data] of Object.entries(resData.data)) {
+      for (const [day, data] of Object.entries(resData)) {
         for (const item of data) {
           events.push({
             title: item.name + '#' + item.employeeNumber.slice(0, 3),
@@ -69,11 +69,11 @@ const CalendarForm = () => {
         customButtons={{
           prev: {
             icon: 'chevron-left',
+            // split의 타입에러를 수정하기
             click: () => {
               if (calendarRef.current?.getApi()) {
                 calendarRef.current.getApi().prev()
-                const calendarMonth: string | undefined = _.get(calendarRef.current.getApi(), 'currentData.viewTitle')
-                console.log(calendarMonth.split('년')[0], calendarMonth.split('년')[1].split('월')[0])
+                const calendarMonth: string = calendarRef.current.getApi().view.title
                 setYear(Number(calendarMonth.split('년')[0]))
                 setMonth(Number(calendarMonth.split('년')[1].split('월')[0]))
               }
@@ -84,8 +84,7 @@ const CalendarForm = () => {
             click: () => {
               if (calendarRef.current?.getApi()) {
                 calendarRef.current.getApi().next()
-                const calendarMonth: string | undefined = _.get(calendarRef.current.getApi(), 'currentData.viewTitle')
-                console.log(calendarMonth.split('년')[0], calendarMonth.split('년')[1].split('월')[0])
+                const calendarMonth: string = calendarRef.current.getApi().view.title
                 setYear(Number(calendarMonth.split('년')[0]))
                 setMonth(Number(calendarMonth.split('년')[1].split('월')[0]))
               }

--- a/src/components/main/CalendarForm.tsx
+++ b/src/components/main/CalendarForm.tsx
@@ -30,8 +30,8 @@ const CalendarForm = () => {
   // 년/월에 맞춰서 데이터를 가져온다고 가정
   const fetchDummy = async () => {
     try {
-      const response = await axios.get(`/DummyAllAnnual${year}${month}.json`)
-      const resData: annualData = response.data.data
+      const { data } = await axios.get(`/DummyAllAnnual${year}${month}.json`)
+      const resData: annualData = data.data
       // 이벤트 생성
       const events = []
       for (const [day, data] of Object.entries(resData)) {

--- a/src/index.scss
+++ b/src/index.scss
@@ -114,6 +114,7 @@ body {
   max-width: 1440px;
   position: relative;
   margin: 0 auto;
+  color: #333030;
 }
 ol,
 ul {

--- a/src/index.scss
+++ b/src/index.scss
@@ -93,7 +93,6 @@ video {
   padding: 0;
   border: 0;
   font-size: 100%;
-  font: inherit;
   vertical-align: baseline;
 }
 /* HTML5 display-role reset for older browsers */

--- a/src/layout/MainLayout.module.scss
+++ b/src/layout/MainLayout.module.scss
@@ -1,5 +1,4 @@
 .main {
-  width: 100%;
+  width: 1440px;
   min-height: 100vh;
-  border: 1px solid blue; // 추후 삭제
 }

--- a/src/pages/admin/AdminAnnual.module.scss
+++ b/src/pages/admin/AdminAnnual.module.scss
@@ -15,9 +15,9 @@ h2 {
 }
 
 .tableWrapper {
-  max-height: calc(8.35 * 40px); 
+  max-height: calc(8.35 * 40px);
   overflow-x: hidden;
-  overflow-y: auto; 
+  overflow-y: auto;
   position: relative;
 }
 
@@ -25,24 +25,25 @@ h2 {
   width: 1100px;
 }
 
-thead {
+.thead {
   position: sticky;
   top: 0;
 }
 
-th,td {
+.th,
+.td {
   text-align: center;
-  padding: 8px; 
-  line-height: 2; 
+  padding: 8px;
+  line-height: 2;
   border-bottom: 1px solid #e3dede;
 }
 
-th {
+.th {
   background-color: #e3dede;
   font-weight: bold;
 }
 
-tr:hover  {
+.tr:hover {
   background-color: #e3dede;
 }
 

--- a/src/pages/admin/AdminAnnual.tsx
+++ b/src/pages/admin/AdminAnnual.tsx
@@ -1,114 +1,103 @@
-import style from './AdminAnnual.module.scss';
-import { dummyData2 } from '@/dummy/DummyData';
-import { useState } from "react";
+import style from './AdminAnnual.module.scss'
+import { dummyData2 } from '@/dummy/DummyData'
+import { useState } from 'react'
 
 type Data = {
-  statusCode: number;
+  statusCode: number
   data: {
-    annualId: number;
-    name: string;
-    employeeNumber: string;
-    date: string;
-    status: string;
-  }[];
-};
+    annualId: number
+    name: string
+    employeeNumber: string
+    date: string
+    status: string
+  }[]
+}
 
 const AdminAnnual = () => {
   const [data, setData] = useState<Data>({
     statusCode: 200,
-    data: dummyData2.data});
+    data: dummyData2.data
+  })
 
   const handleApprove = (annualId) => {
-    console.log(`승인 버튼 클릭: ${annualId}`);
-  };
+    console.log(`승인 버튼 클릭: ${annualId}`)
+  }
 
   const handleReject = (annualId) => {
-    console.log(`거부 버튼 클릭: ${annualId}`);
-  };
+    console.log(`거부 버튼 클릭: ${annualId}`)
+  }
 
   return (
     <section className={style.container}>
       <div className={style.contentWrapper}>
         <h2>신청 목록</h2>
         <div className={style.tableWrapper}>
-        <table className={style.table}>
-          <thead>
-            <tr>
-              <th>사원명</th>
-              <th>신청 날짜</th>
-              <th>승인/거부</th>
-            </tr>
-          </thead>
-          <tbody>
-            {data.data
-              .filter((item) => item.status === 'UNAPPROVED')
-              .map((employee) => (
-                <tr key={employee.annualId}>
-                  <td>
-                    {employee.name} {employee.employeeNumber}
-                  </td>
-                  <td>{employee.date}</td>
-                  <td>
-                    <button
-                      className={style.approve}
-                      onClick={() => handleApprove(employee.annualId)}
-                    >
-                      승인
-                    </button>
-                    <button
-                      className={style.delete}
-                      onClick={() => handleReject(employee.annualId)}
-                    >
-                      거부
-                    </button>
-                  </td>
-                </tr>
-              ))}
-          </tbody>
-        </table>
+          <table className={style.table}>
+            <thead>
+              <tr className={style.tr}>
+                <th className={style.th}>사원명</th>
+                <th className={style.th}>신청 날짜</th>
+                <th className={style.th}>승인/거부</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.data
+                .filter((item) => item.status === 'UNAPPROVED')
+                .map((employee) => (
+                  <tr key={employee.annualId} className={style.tr}>
+                    <td className={style.td}>
+                      {employee.name} {employee.employeeNumber}
+                    </td>
+                    <td className={style.td}>{employee.date}</td>
+                    <td className={style.td}>
+                      <button className={style.approve} onClick={() => handleApprove(employee.annualId)}>
+                        승인
+                      </button>
+                      <button className={style.delete} onClick={() => handleReject(employee.annualId)}>
+                        거부
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+            </tbody>
+          </table>
         </div>
 
         <h2>취소 신청 목록</h2>
         <div className={style.tableWrapper}>
-        <table className={style.table}>
-          <thead>
-            <tr>
-              <th>사원명</th>
-              <th>신청 날짜</th>
-              <th>승인/거부</th>
-            </tr>
-          </thead>
-          <tbody>
-            {data.data
-              .filter((item) => item.status === 'CANCELED')
-              .map((employee) => (
-                <tr key={employee.annualId}>
-                  <td>
-                    {employee.name} {employee.employeeNumber}
-                  </td>
-                  <td>{employee.date}</td>
-                  <td>
-                    <button
-                      className={style.approve}
-                      onClick={() => handleApprove(employee.annualId)}
-                    >
-                      승인
-                    </button>
-                    <button
-                      className={style.delete}
-                      onClick={() => handleReject(employee.annualId)}
-                    >
-                      거부
-                    </button>
-                  </td>
-                </tr>
-              ))}
-          </tbody>
-        </table>
+          <table className={style.table}>
+            <thead>
+              <tr className={style.tr}>
+                <th className={style.th}>사원명</th>
+                <th className={style.th}>신청 날짜</th>
+                <th className={style.th}>승인/거부</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.data
+                .filter((item) => item.status === 'CANCELED')
+                .map((employee) => (
+                  <tr key={employee.annualId}>
+                    <td className={style.td}>
+                      {employee.name} {employee.employeeNumber}
+                    </td>
+                    <td className={style.td}>{employee.date}</td>
+                    <td className={style.td}>
+                      <button className={style.approve} onClick={() => handleApprove(employee.annualId)}>
+                        승인
+                      </button>
+                      <button className={style.delete} onClick={() => handleReject(employee.annualId)}>
+                        거부
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+            </tbody>
+          </table>
         </div>
       </div>
     </section>
-  );
-};
+  )
+}
 
-export default AdminAnnual;
+export default AdminAnnual

--- a/src/types/AccessTypes.ts
+++ b/src/types/AccessTypes.ts
@@ -22,7 +22,7 @@ export interface LoginResData {
 export interface User {
   email: string
   name: string
-  employNumber: string
+  employeeNumber: string
   role: 'ROLE_ADMIN' | 'ROLE_USER'
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,5 +4,10 @@ import tsconfigPaths from 'vite-tsconfig-paths'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), tsconfigPaths()]
+  plugins: [react(), tsconfigPaths()],
+  resolve: {
+    alias: {
+      '@': '/src'
+    }
+  }
 })


### PR DESCRIPTION
accessTypes의 로그인 응답 오타를 수정했습니다. 노션에도 오타인 상태로 적혀있어서, 노션도 수정했습니다.
변경 전
```
{
  email: string
  name: string
  employNumber: string
  role: 'ROLE_ADMIN' | 'ROLE_USER'
}
```
변경 후
```
{
  email: string
  name: string
  employeeNumber: string
  role: 'ROLE_ADMIN' | 'ROLE_USER'
}
```
ee가 빠져있더라구요.😅

mainHeader와 mainFooter를 추가했습니다. 원래 로그인이 안되어있으면 메인으로 이동할 수 없어야 하지만, 
로그인 기능이 구현 안된 관계로 더미 유저 데이터만 받아서 작성했습니다.

로그인 기능이 구현되면, token이 있을 때(로그인 상태일 때)만 보이도록 수정하겠습니다.