### PR TITLE
Feat/mainpage filtering #57

### DIFF
--- a/src/api/main/index.ts
+++ b/src/api/main/index.ts
@@ -5,7 +5,7 @@ import { workData, annualApplyReq, annualApplyData, annualData } from '@/types/M
 export const getAnnualApi = async (year: number, month: number) => {
   try {
     const res = await baseApi.get(`/schedule/annual?year=${year}&month=${month}`)
-    return res.data.data as annualData
+    if (res.status === 200) return res.data.data as annualData
   } catch (error) {
     console.error('연차 일정 목록을 불러올 수 없습니다.', error)
   }

--- a/src/api/mypage/index.ts
+++ b/src/api/mypage/index.ts
@@ -4,30 +4,30 @@ import { annualUserData, annualCancelData, workUserData } from '@/types/MypageTy
 // 개인 연차 조회
 export const getUserAnnualApi = async (token: string, year: number) => {
   try {
-    const res = await baseApi<annualUserData>({
-      method: 'POST',
+    const res = await baseApi({
+      method: 'GET',
       url: `/user/annual?year=${year}`,
       headers: {
         Authorization: `Bearer ${token}`
       }
     })
-    return res.data
+    if (res.status === 200) return res.data.data as annualUserData
   } catch (error) {
     console.error('개인 연차 조회 api 오류', error)
   }
 }
 
 // 개인 당직 조회
-export const getUserWorkApi = async (token: string, year: number) => {
+export const getUserWorkApi = async (token: string, year: number, month: number) => {
   try {
-    const res = await baseApi<workUserData>({
-      method: 'POST',
-      url: `/user/work?year=${year}`,
+    const res = await baseApi({
+      method: 'GET',
+      url: `/user/work?year=${year}&month=${month}`,
       headers: {
         Authorization: `Bearer ${token}`
       }
     })
-    return res.data
+    if (res.status === 200) return res.data.data as workUserData
   } catch (error) {
     console.error('개인 당직 조회 api 오류', error)
   }

--- a/src/components/common/MainHeader.tsx
+++ b/src/components/common/MainHeader.tsx
@@ -55,7 +55,7 @@ const MainHeader = () => {
             <span style={{ marginLeft: '10px' }}>전체 일정 보기</span>
           </div>
           <div
-            className={`${style.navItem} ${location.pathname === '/mypage' ? style.active : ''}`}
+            className={`${style.navItem} ${location.pathname.includes('/mypage') ? style.active : ''}`}
             onClick={handleLink}
           >
             <BsPersonBadgeFill size="20" />

--- a/src/components/main/AnnualApplyModal.tsx
+++ b/src/components/main/AnnualApplyModal.tsx
@@ -23,7 +23,7 @@ const AnnaulApplyModal = ({ dateInfo, setShowModal }: Props) => {
       if (Array.isArray(res)) {
         alert('연차 신청에 실패했습니다.')
       } else {
-        alert('연차 신청이 완료되었습니다! 관리자 승인 후 반영됩니다. 마이페이지에서 확인해주세요.')
+        alert('연차 신청이 완료되었습니다! 관리자 승인 후 반영됩니다.')
       }
     })
 

--- a/src/components/main/CalendarForm.module.scss
+++ b/src/components/main/CalendarForm.module.scss
@@ -7,4 +7,16 @@
   background-color: #fff;
   box-shadow: 1px 5px 10px $description_primary-2;
   padding: 15px;
+  overflow-y: hidden;
+  .indicator {
+    width: 100%;
+    margin-top: 10px;
+    display: flex;
+    justify-content: flex-end;
+    .item {
+      display: flex;
+      align-items: center;
+      margin-right: 20px;
+    }
+  }
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -165,3 +165,15 @@ table {
   color: red;
   text-decoration: none;
 }
+
+.fc-col-header-cell-cushion {
+  margin-top: 4px !important;
+}
+
+.fc-daygrid-day.fc-day-today {
+  background-color: #e6f0ff !important;
+}
+
+.fc-event {
+  margin-bottom: 3px !important;
+}

--- a/src/types/MainTypes.ts
+++ b/src/types/MainTypes.ts
@@ -14,6 +14,7 @@ export interface annualInfo {
   name: string // 연차 사용자 이름
   employeeNumber: string // 연차 사용자 사원번호
   date: string // 당직 날짜
+  status: 'APPROVED' | 'CANCELED' | 'UNAPPROVED' // 연차 상태
 }
 
 // 일정 목록 조회(당직)


### PR DESCRIPTION
[#57] feat: 메인페이지 내 연차/당직 조회 필터링 및 지표 추가
[#57] style: event 및 Calendar 요일 margin 수정
[#46] fix: 마이페이지 개인 연차/당직 조회 api 수정(POST -> GET)
MainHeader active수정

#### 전체 연차 / 당직 조회

![image](https://github.com/FAST-Mini-Project/front-end/assets/84277185/09ee31b3-df1a-4621-a9f2-1d599cbc1ebf)

+ 연차 / 당직 이벤트 색상 변경
+ 승인된 연차 / 취소된 연차 필터링 추가

#### 내 연차 / 당직 조회

![image](https://github.com/FAST-Mini-Project/front-end/assets/84277185/180a1667-5976-4ffa-9c92-6a452760ec7d)

+ 내 연차 / 당직 이벤트 로직 추가
+ 승인된 연차 / 신청한 연차 / 취소된 연차 필터링

#### mypage API 수정
```
// 개인 연차 조회
export const getUserAnnualApi = async (token: string, year: number) => {
  try {
    const res = await baseApi({
      method: 'GET',
      url: `/user/annual?year=${year}`,
      headers: {
        Authorization: `Bearer ${token}`
      }
    })
    if (res.status === 200) return res.data.data as annualUserData
  } catch (error) {
    console.error('개인 연차 조회 api 오류', error)
  }
}

// 개인 당직 조회
export const getUserWorkApi = async (token: string, year: number, month: number) => {
  try {
    const res = await baseApi({
      method: 'GET',
      url: `/user/work?year=${year}&month=${month}`,
      headers: {
        Authorization: `Bearer ${token}`
      }
    })
    if (res.status === 200) return res.data.data as workUserData
  } catch (error) {
    console.error('개인 당직 조회 api 오류', error)
  }
}
```
+ method가 POST로 되어있어 api 오류 발생..죄송합니다. GET으로 수정
+ 타입 에러 해결 및 status 200 예외처리